### PR TITLE
Update: Lib dependencies and build environment

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -30,8 +30,9 @@ lib_deps_generic_external =
 	Adafruit HTU21DF Library@1.0.2
 	ArduinoJson@6.13.0
 	DallasTemperature@3.8.0
-	ESP8266_SSD1306@4.1.0
+	ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
 	797@1.0.1
+	https://github.com/CodeForAfrica/sensors.AFRICA-Adafruit_FONA.git
 lib_deps_esp8266_platform = 
 	Hash
 	Wire
@@ -84,7 +85,7 @@ build_flags = ${common.build_flags_esp32_release} '-DINTL_DE' '-DESP32_WROOM_MOD
 lib_deps = ${common.lib_deps_esp32}
 extra_scripts = ${common.extra_scripts}
 
-[env:nodemcuv2]
+[DISABLEDenv:nodemcuv2]
 lang = de
 platform = ${common.platform_version}
 framework = arduino


### PR DESCRIPTION
Link FONA library. Update OLED lib. Build only in English

## Description

Include [sensors.AFRICA Adafruit FONA lib](https://github.com/CodeForAfrica/sensors.AFRICA-Adafruit_FONA.git).
Update the OLED lib as reviewed in the AQ-Software
Build only in English.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Update ( non-breaking)



## Screenshots

<img width="901" alt="Screenshot 2024-01-29 at 11 05 45" src="https://github.com/CodeForAfrica/sensors.AFRICA-Noise-sensors-software/assets/17834362/8ff33a29-78c1-4dd1-8e91-afff3198cff2">


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

